### PR TITLE
feat!: modernize library to v2.0.0

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -16,6 +16,7 @@
   ],
   "useGitignore": true,
   "words": [
-    "yako_theme_switch"
+    "yako_theme_switch",
+    "Yako"
   ]
 }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,3 +23,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
+      min_coverage: 70

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,12 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for OIDC publishing to pub.dev
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## [2.0.0] - [Apr 9, 2026]
 
-### Breaking Changes
-* `onChanged` callback signature changed from `Function({bool changed})` to `ValueChanged<bool>` (i.e. `void Function(bool)`).
-  Migrate: `onChanged: ({bool? changed}) {}` → `onChanged: (bool value) {}`
-
 ### Improvements
 * Added `super.key` to constructor — widgets can now be identified by key.
 * State class fields are now private (`_animationController`, `_turnState`, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,30 @@
+## [2.0.0] - [Apr 9, 2026]
+
+### Breaking Changes
+* `onChanged` callback signature changed from `Function({bool changed})` to `ValueChanged<bool>` (i.e. `void Function(bool)`).
+  Migrate: `onChanged: ({bool? changed}) {}` → `onChanged: (bool value) {}`
+
+### Improvements
+* Added `super.key` to constructor — widgets can now be identified by key.
+* State class fields are now private (`_animationController`, `_turnState`, etc.).
+* `createState` uses `State<YakoThemeSwitch>` return type annotation.
+* `const Color(...)` used for default color literals.
+* Removed redundant `addPostFrameCallback` animation trigger in `initState` — eliminates a visual flash on initial render.
+* `onChanged` callback is now called outside `setState`, following Flutter best practices.
+* Replaced bare `Container` with `SizedBox` for the toggle hit area (semantic clarity).
+
+### Dependency Updates
+* `flutter_svg` bumped from `^2.0.7` to `^2.2.3`
+* `mocktail` bumped from `^0.3.0` to `^1.0.4`
+* `flutter_lints` bumped from `^2.0.0` to `^6.0.0`
+* Minimum Flutter SDK raised from `>=3.10.0` to `>=3.27.0`
+* Minimum Dart SDK raised from `>=3.0.0` to `>=3.4.0`
+
+### Tests
+* Replaced empty/commented test suite with 11 widget tests covering:
+  rendering, default state, enabled state, tap callbacks, external prop
+  updates, custom width, custom colors, custom duration, border radius,
+  key support, and multi-tap alternation.
+
 ## [1.0.0+1] - [Jul 9, 2023]
 * First release

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Just a cool switch for your app's theme
 In your pubspec.yaml
 ```yaml
 dependencies:
-  yako_theme_switch: ^1.0.0
+  yako_theme_switch: ^2.0.0
 ```
 <br>
 
@@ -19,14 +19,18 @@ dependencies:
 ```dart
     YakoThemeSwitch(
       enabled: themeMode == ThemeMode.light,
-      onChanged: ({bool? changed}) {},
+      onChanged: (bool value) {
+        setState(() => themeMode = value ? ThemeMode.light : ThemeMode.dark);
+      },
     );
 ```
 ## Advanced usage
 ```dart
     YakoThemeSwitch(
       enabled: themeMode == ThemeMode.light,
-      onChanged: ({bool? changed}) {},
+      onChanged: (bool value) {
+        setState(() => themeMode = value ? ThemeMode.light : ThemeMode.dark);
+      },
       width: 50,
       enabledBackgroundColor: Colors.blue,
       disabledBackgroundColor: Colors.red,
@@ -35,6 +39,18 @@ dependencies:
       animationDuration: const Duration(milliseconds: 300),
       enabledToggleBorderRadius: 8,
     ),
+```
+
+## Migrating from v1.x
+
+The `onChanged` callback signature changed in v2.0.0:
+
+```dart
+// v1.x (old)
+onChanged: ({bool? changed}) { /* use changed */ }
+
+// v2.0.0 (new)
+onChanged: (bool value) { /* use value */ }
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -41,18 +41,6 @@ dependencies:
     ),
 ```
 
-## Migrating from v1.x
-
-The `onChanged` callback signature changed in v2.0.0:
-
-```dart
-// v1.x (old)
-onChanged: ({bool? changed}) { /* use changed */ }
-
-// v2.0.0 (new)
-onChanged: (bool value) { /* use value */ }
-```
-
 <br>
 
 

--- a/lib/src/yako_theme_switch.dart
+++ b/lib/src/yako_theme_switch.dart
@@ -8,8 +8,8 @@ class YakoThemeSwitch extends StatefulWidget {
   /// You can set the custom width of the switch
   final double width;
 
-  /// Just a callback function to get the changed state of the switch
-  final Function({bool changed}) onChanged;
+  /// Callback invoked with the new state whenever the switch is toggled
+  final ValueChanged<bool> onChanged;
 
   /// The background color of the switch when it is enabled
   final Color? enabledBackgroundColor;
@@ -26,10 +26,11 @@ class YakoThemeSwitch extends StatefulWidget {
   /// The duration of the animation
   final Duration animationDuration;
 
-  /// The border radius of the toggle. Try setting it to 4 and chech how circle now is square
+  /// The border radius of the toggle. Try setting it to 4 to make the circle square
   final double? enabledToggleBorderRadius;
 
   const YakoThemeSwitch({
+    super.key,
     this.enabled = false,
     this.width = 45,
     this.enabledBackgroundColor,
@@ -42,23 +43,23 @@ class YakoThemeSwitch extends StatefulWidget {
   });
 
   @override
-  _YakoThemeSwitchState createState() => _YakoThemeSwitchState();
+  State<YakoThemeSwitch> createState() => _YakoThemeSwitchState();
 }
 
 class _YakoThemeSwitchState extends State<YakoThemeSwitch>
     with SingleTickerProviderStateMixin {
-  late AnimationController animationController;
-  late Animation<double> animation;
-  late bool turnState;
-  late Color enabledBackgroundColor;
-  late Color disabledBackgroundColor;
-  late Color enabledToggleColor;
-  late Color disabledToggleColor;
-  double animationControllerValue = 0.0;
+  late AnimationController _animationController;
+  late Animation<double> _animation;
+  late bool _turnState;
+  late Color _enabledBackgroundColor;
+  late Color _disabledBackgroundColor;
+  late Color _enabledToggleColor;
+  late Color _disabledToggleColor;
+  double _animationValue = 0.0;
 
   @override
   void dispose() {
-    animationController.dispose();
+    _animationController.dispose();
     super.dispose();
   }
 
@@ -66,37 +67,33 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
   void initState() {
     super.initState();
 
-    enabledBackgroundColor =
+    _enabledBackgroundColor =
         widget.enabledBackgroundColor ?? Colors.grey.shade300;
-    disabledBackgroundColor =
-        widget.disabledBackgroundColor ?? Color(0xFF2E386E);
-    enabledToggleColor =
+    _disabledBackgroundColor =
+        widget.disabledBackgroundColor ?? const Color(0xFF2E386E);
+    _enabledToggleColor =
         widget.enabledToggleColor ?? Colors.amberAccent.shade700;
-    disabledToggleColor = widget.disabledToggleColor ?? Color(0xFF70E2FB);
+    _disabledToggleColor =
+        widget.disabledToggleColor ?? const Color(0xFF70E2FB);
 
-    animationControllerValue = widget.enabled ? 1.0 : 0.0;
-    animationController = AnimationController(
-      value: animationControllerValue,
+    _turnState = widget.enabled;
+    _animationValue = widget.enabled ? 1.0 : 0.0;
+
+    _animationController = AnimationController(
+      value: _animationValue,
       vsync: this,
       lowerBound: 0.0,
       upperBound: 1.0,
       duration: widget.animationDuration,
     );
-    animation =
-        CurvedAnimation(parent: animationController, curve: Curves.easeInOut);
+    _animation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    );
 
-    animationController.addListener(() {
+    _animationController.addListener(() {
       setState(() {
-        animationControllerValue = animation.value;
-      });
-    });
-    turnState = widget.enabled;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        if (turnState) {
-          animationController.forward();
-        }
+        _animationValue = _animation.value;
       });
     });
   }
@@ -105,13 +102,12 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
   void didUpdateWidget(YakoThemeSwitch oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    // if enabled value is updated, reflect the change in switch
     if (oldWidget.enabled != widget.enabled) {
-      turnState = widget.enabled;
-      if (turnState) {
-        animationController.forward();
+      _turnState = widget.enabled;
+      if (_turnState) {
+        _animationController.forward();
       } else {
-        animationController.reverse();
+        _animationController.reverse();
       }
     }
   }
@@ -119,15 +115,13 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
   @override
   Widget build(BuildContext context) {
     final Color? transitionColor = Color.lerp(
-      disabledBackgroundColor,
-      enabledBackgroundColor,
-      animationControllerValue,
+      _disabledBackgroundColor,
+      _enabledBackgroundColor,
+      _animationValue,
     );
 
     return GestureDetector(
-      onTap: () {
-        toggle(changeState: true);
-      },
+      onTap: _toggle,
       child: Container(
         padding: const EdgeInsets.all(3),
         width: widget.width,
@@ -138,23 +132,21 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
         child: Stack(
           children: <Widget>[
             Transform.translate(
-              offset: Offset((widget.width - 25) * animationControllerValue, 0),
+              offset: Offset((widget.width - 25) * _animationValue, 0),
               child: Transform.rotate(
-                angle: animationControllerValue,
-                child: Container(
+                angle: _animationValue,
+                child: SizedBox(
                   height: 18,
                   width: 18,
-                  alignment: Alignment.center,
                   child: Stack(
                     children: <Widget>[
                       Center(
                         child: Opacity(
-                          opacity:
-                              (1 - animationControllerValue).clamp(0.0, 1.0),
+                          opacity: (1 - _animationValue).clamp(0.0, 1.0),
                           child: SvgPicture.asset(
                             'assets/dark_mode_switch_icon.svg',
                             colorFilter: ColorFilter.mode(
-                              disabledToggleColor,
+                              _disabledToggleColor,
                               BlendMode.srcIn,
                             ),
                             height: 18,
@@ -164,12 +156,13 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
                       ),
                       Center(
                         child: Opacity(
-                          opacity: animationControllerValue.clamp(0.0, 1.0),
+                          opacity: _animationValue.clamp(0.0, 1.0),
                           child: Container(
                             decoration: BoxDecoration(
                               borderRadius: BorderRadius.circular(
-                                  widget.enabledToggleBorderRadius ?? 20),
-                              color: enabledToggleColor,
+                                widget.enabledToggleBorderRadius ?? 20,
+                              ),
+                              color: _enabledToggleColor,
                             ),
                           ),
                         ),
@@ -178,19 +171,22 @@ class _YakoThemeSwitchState extends State<YakoThemeSwitch>
                   ),
                 ),
               ),
-            )
+            ),
           ],
         ),
       ),
     );
   }
 
-  void toggle({bool changeState = false}) {
+  void _toggle() {
     setState(() {
-      if (changeState) turnState = !turnState;
-      turnState ? animationController.forward() : animationController.reverse();
-
-      widget.onChanged(changed: turnState);
+      _turnState = !_turnState;
+      if (_turnState) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse();
+      }
     });
+    widget.onChanged(_turnState);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yako_theme_switch
 description: Custom switch that looks good for changing the theme of the app
-version: 1.0.0+1
+version: 2.0.0
 repository: https://github.com/yako-dev/flutter-yako-theme-switch
 issue_tracker: https://github.com/yako-dev/flutter-yako-theme-switch/issues
 
@@ -12,19 +12,19 @@ screenshots:
     path: assets/showcase_animation.gif
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_svg: ^2.0.7
+  flutter_svg: ^2.2.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mocktail: ^0.3.0
-  flutter_lints: ^2.0.0
+  mocktail: ^1.0.4
+  flutter_lints: ^6.0.0
 
 flutter:
   assets:

--- a/test/src/yako_theme_switch_test.dart
+++ b/test/src/yako_theme_switch_test.dart
@@ -1,11 +1,241 @@
-// ignore_for_file: prefer_const_constructors
-
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:yako_theme_switch/yako_theme_switch.dart';
 
 void main() {
   group('YakoThemeSwitch', () {
-    test('can be instantiated', () {
-      // expect(YakoThemeSwitch(), isNotNull);
+    testWidgets('renders without error', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('starts in disabled (dark) state by default', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // enabled defaults to false — widget should be present and stable
+      expect(find.byType(GestureDetector), findsOneWidget);
+    });
+
+    testWidgets('starts in enabled (light) state when enabled: true',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              enabled: true,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged with true when tapped from disabled state',
+        (tester) async {
+      bool? received;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              enabled: false,
+              onChanged: (value) => received = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+
+      expect(received, isTrue);
+    });
+
+    testWidgets('calls onChanged with false when tapped from enabled state',
+        (tester) async {
+      bool? received;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              enabled: true,
+              onChanged: (value) => received = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+
+      expect(received, isFalse);
+    });
+
+    testWidgets('responds to external enabled prop change via didUpdateWidget',
+        (tester) async {
+      bool switchEnabled = false;
+      bool? callbackValue;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    YakoThemeSwitch(
+                      enabled: switchEnabled,
+                      onChanged: (value) {
+                        callbackValue = value;
+                      },
+                    ),
+                    ElevatedButton(
+                      onPressed: () => setState(() => switchEnabled = true),
+                      child: const Text('Enable'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+      // callbackValue not set — external prop change does not call onChanged
+      expect(callbackValue, isNull);
+    });
+
+    testWidgets('accepts custom width', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              width: 80,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('accepts custom colors', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              enabledBackgroundColor: Colors.blue,
+              disabledBackgroundColor: Colors.red,
+              enabledToggleColor: Colors.green,
+              disabledToggleColor: Colors.purple,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('accepts custom animationDuration', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              animationDuration: const Duration(milliseconds: 100),
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('accepts custom enabledToggleBorderRadius', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              enabledToggleBorderRadius: 4,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(YakoThemeSwitch), findsOneWidget);
+    });
+
+    testWidgets('accepts a key', (tester) async {
+      const key = Key('theme_switch');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              key: key,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(key), findsOneWidget);
+    });
+
+    testWidgets('can be tapped multiple times alternating state',
+        (tester) async {
+      final received = <bool>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: YakoThemeSwitch(
+              onChanged: received.add,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+
+      expect(received, [true, false, true]);
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Breaking:** `onChanged` signature changed to `ValueChanged<bool>` — cleaner, idiomatic Flutter API
- Bumped all dependencies to latest: `flutter_svg ^2.2.3`, `mocktail ^1.0.4`, `flutter_lints ^6.0.0`
- Raised SDK floor to Flutter `>=3.27.0` / Dart `>=3.4.0`
- Fixed animation double-trigger flash on initial render
- Added `super.key`, private state fields, `const Color` literals, proper `createState` annotation
- Replaced empty test suite with 11 real widget tests
- Updated README examples and install version

## Test plan

- [ ] CI passes (flutter_package workflow runs tests + coverage check at 70%)
- [ ] Spell check passes on markdown files
- [ ] Semantic PR check passes